### PR TITLE
Fix README dir for plugin patching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,7 @@ tasks {
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription(
             closure {
-                File("./README.md").readText().lines().run {
+                File("$projectDir/README.md").readText().lines().run {
                     val start = "<!-- Plugin description -->"
                     val end = "<!-- Plugin description end -->"
 


### PR DESCRIPTION
This PR specifies the project directory for the `patchPluginXml` task.  This resolves an issue where builds initiated from within IntelliJ would not correctly locate the README needed for supplying the plugin description.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
