### PR TITLE
Upgrade gradle-intellij-plugin to 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Java ${{ matrix.java }} ${{ matrix.os }}
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11, 17]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,40 +13,26 @@
  * permissions and limitations under the License.
  */
 
-import org.jetbrains.changelog.closure
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
+
+fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
     // Java support
     id("java")
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij") version "0.7.2"
+    id("org.jetbrains.intellij") version "1.4.0"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "0.6.2"
+    id("org.jetbrains.changelog") version "1.3.1"
     id("checkstyle")
     id("com.github.spotbugs") version "5.0.6"
     id("org.jetbrains.grammarkit") version "2021.1.2"
 }
 
-// Import variables from gradle.properties file
-val pluginGroup: String by project
-// `pluginName_` variable ends with `_` because of the collision with Kotlin magic getter in the `intellij` closure.
-// Read more about the issue: https://github.com/JetBrains/intellij-platform-plugin-template/issues/29
-val pluginName_: String by project
-val pluginVersion: String by project
-val pluginSinceBuild: String by project
-val pluginUntilBuild: String by project
-val pluginVerifierIdeVersions: String by project
-
-val platformType: String by project
-val platformVersion: String by project
-val platformPlugins: String by project
-val platformDownloadSources: String by project
-
-group = pluginGroup
-version = pluginVersion
+group = properties("pluginGroup")
+version = properties("pluginVersion")
 
 // Configure project's dependencies
 repositories {
@@ -63,14 +49,12 @@ dependencies {
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    pluginName = pluginName_
-    version = platformVersion
-    type = platformType
-    downloadSources = platformDownloadSources.toBoolean()
-    updateSinceUntilBuild = true
+    pluginName.set(properties("pluginName"))
+    version.set(properties("platformVersion"))
+    type.set(properties("platformType"))
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    setPlugins(*platformPlugins.split(',').map(String::trim).filter(String::isNotEmpty).toTypedArray())
+    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
 }
 
 sourceSets["main"].java.srcDirs("src/main/gen")
@@ -145,14 +129,13 @@ tasks {
     }
 
     patchPluginXml {
-        version(pluginVersion)
-        sinceBuild(pluginSinceBuild)
-        untilBuild(pluginUntilBuild)
+        version.set(properties("pluginVersion"))
+        sinceBuild.set(properties("pluginSinceBuild"))
+        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription(
-            closure {
-                File("$projectDir/README.md").readText().lines().run {
+        pluginDescription.set(
+                projectDir.resolve("README.md").readText().lines().run {
                     val start = "<!-- Plugin description -->"
                     val end = "<!-- Plugin description end -->"
 
@@ -161,27 +144,22 @@ tasks {
                     }
                     subList(indexOf(start) + 1, indexOf(end))
                 }.joinToString("\n").run { markdownToHTML(this) }
-            }
         )
 
         // Get the latest available change notes from the changelog file
-        changeNotes(
-            closure {
-                changelog.getLatest().toHTML()
-            }
-        )
-    }
-
-    runPluginVerifier {
-        ideVersions(pluginVerifierIdeVersions)
+        changeNotes.set(provider {
+            changelog.run {
+                getOrNull(properties("pluginVersion")) ?: getLatest()
+            }.toHTML()
+        })
     }
 
     publishPlugin {
         dependsOn("patchChangelog")
-        token(System.getenv("PUBLISH_TOKEN"))
+        token.set(System.getenv("PUBLISH_TOKEN"))
         // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
         // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
-        // https://jetbrains.org/intellij/sdk/docs/tutorials/build_system/deployment.html#specifying-a-release-channel
-        channels(pluginVersion.split('-').getOrElse(1) { "default" }.split('.').first())
+        // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+        channels.set(listOf(properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,21 +2,29 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = software.amazon.smithy.plugins
-pluginName_ = Smithy IntelliJ
+pluginName = Smithy IntelliJ
 pluginVersion = 0.0.1
-pluginSinceBuild = 193
-pluginUntilBuild = 203.*
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
-# See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.1.4, 2020.2.3, 2020.3
 
+# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# for insight into build numbers and IntelliJ Platform versions.
+pluginSinceBuild = 211
+pluginUntilBuild = 213.*
+
+# IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2020.1
-platformDownloadSources = true
-# Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
+platformVersion = 2021.1.3
+
+# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins =
 
+# Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
+javaVersion = 11
+
+# Gradle Releases -> https://github.com/gradle/gradle/releases
+gradleVersion = 7.4
+
 # Opt-out flag for bundling Kotlin standard library.
-# See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
+# See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
+# suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency = false

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyAbsoluteRootShapeIdImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyAbsoluteRootShapeIdImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyAbsoluteRootShapeIdImpl extends ASTWrapperPsiElement implements SmithyAbsoluteRootShapeId {
 
-  public SmithyAbsoluteRootShapeIdImpl(ASTNode node) {
+  public SmithyAbsoluteRootShapeIdImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyApplyStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyApplyStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyApplyStatementImpl extends ASTWrapperPsiElement implements SmithyApplyStatement {
 
-  public SmithyApplyStatementImpl(ASTNode node) {
+  public SmithyApplyStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyCommentImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyCommentImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyCommentImpl extends ASTWrapperPsiElement implements SmithyComment {
 
-  public SmithyCommentImpl(ASTNode node) {
+  public SmithyCommentImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyComplexShapeStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyComplexShapeStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyComplexShapeStatementImpl extends ASTWrapperPsiElement implements SmithyComplexShapeStatement {
 
-  public SmithyComplexShapeStatementImpl(ASTNode node) {
+  public SmithyComplexShapeStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyMetadataSectionImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyMetadataSectionImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyMetadataSectionImpl extends ASTWrapperPsiElement implements SmithyMetadataSection {
 
-  public SmithyMetadataSectionImpl(ASTNode node) {
+  public SmithyMetadataSectionImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyMetadataStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyMetadataStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyMetadataStatementImpl extends ASTWrapperPsiElement implements SmithyMetadataStatement {
 
-  public SmithyMetadataStatementImpl(ASTNode node) {
+  public SmithyMetadataStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNamespaceImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNamespaceImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNamespaceImpl extends ASTWrapperPsiElement implements SmithyNamespace {
 
-  public SmithyNamespaceImpl(ASTNode node) {
+  public SmithyNamespaceImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNamespaceStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNamespaceStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNamespaceStatementImpl extends ASTWrapperPsiElement implements SmithyNamespaceStatement {
 
-  public SmithyNamespaceStatementImpl(ASTNode node) {
+  public SmithyNamespaceStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeArrayImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeArrayImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeArrayImpl extends ASTWrapperPsiElement implements SmithyNodeArray {
 
-  public SmithyNodeArrayImpl(ASTNode node) {
+  public SmithyNodeArrayImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeObjectImpl extends ASTWrapperPsiElement implements SmithyNodeObject {
 
-  public SmithyNodeObjectImpl(ASTNode node) {
+  public SmithyNodeObjectImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectKeyImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectKeyImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeObjectKeyImpl extends ASTWrapperPsiElement implements SmithyNodeObjectKey {
 
-  public SmithyNodeObjectKeyImpl(ASTNode node) {
+  public SmithyNodeObjectKeyImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectKvpImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectKvpImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeObjectKvpImpl extends ASTWrapperPsiElement implements SmithyNodeObjectKvp {
 
-  public SmithyNodeObjectKvpImpl(ASTNode node) {
+  public SmithyNodeObjectKvpImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectShapeStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeObjectShapeStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeObjectShapeStatementImpl extends ASTWrapperPsiElement implements SmithyNodeObjectShapeStatement {
 
-  public SmithyNodeObjectShapeStatementImpl(ASTNode node) {
+  public SmithyNodeObjectShapeStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeStringValueImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeStringValueImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeStringValueImpl extends ASTWrapperPsiElement implements SmithyNodeStringValue {
 
-  public SmithyNodeStringValueImpl(ASTNode node) {
+  public SmithyNodeStringValueImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeValueImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNodeValueImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNodeValueImpl extends ASTWrapperPsiElement implements SmithyNodeValue {
 
-  public SmithyNodeValueImpl(ASTNode node) {
+  public SmithyNodeValueImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNumberImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyNumberImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyNumberImpl extends ASTWrapperPsiElement implements SmithyNumber {
 
-  public SmithyNumberImpl(ASTNode node) {
+  public SmithyNumberImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyRootShapeIdImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyRootShapeIdImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyRootShapeIdImpl extends ASTWrapperPsiElement implements SmithyRootShapeId {
 
-  public SmithyRootShapeIdImpl(ASTNode node) {
+  public SmithyRootShapeIdImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeBodyImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeBodyImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeBodyImpl extends ASTWrapperPsiElement implements SmithyShapeBody {
 
-  public SmithyShapeBodyImpl(ASTNode node) {
+  public SmithyShapeBodyImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeIdImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeIdImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeIdImpl extends ASTWrapperPsiElement implements SmithyShapeId {
 
-  public SmithyShapeIdImpl(ASTNode node) {
+  public SmithyShapeIdImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeMemberKvpImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeMemberKvpImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeMemberKvpImpl extends ASTWrapperPsiElement implements SmithyShapeMemberKvp {
 
-  public SmithyShapeMemberKvpImpl(ASTNode node) {
+  public SmithyShapeMemberKvpImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeMembersImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeMembersImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeMembersImpl extends ASTWrapperPsiElement implements SmithyShapeMembers {
 
-  public SmithyShapeMembersImpl(ASTNode node) {
+  public SmithyShapeMembersImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeSectionImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeSectionImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeSectionImpl extends ASTWrapperPsiElement implements SmithyShapeSection {
 
-  public SmithyShapeSectionImpl(ASTNode node) {
+  public SmithyShapeSectionImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeStatementImpl extends ASTWrapperPsiElement implements SmithyShapeStatement {
 
-  public SmithyShapeStatementImpl(ASTNode node) {
+  public SmithyShapeStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeStatementsImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyShapeStatementsImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyShapeStatementsImpl extends ASTWrapperPsiElement implements SmithyShapeStatements {
 
-  public SmithyShapeStatementsImpl(ASTNode node) {
+  public SmithyShapeStatementsImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithySimpleShapeStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithySimpleShapeStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithySimpleShapeStatementImpl extends ASTWrapperPsiElement implements SmithySimpleShapeStatement {
 
-  public SmithySimpleShapeStatementImpl(ASTNode node) {
+  public SmithySimpleShapeStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitBodyImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitBodyImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyTraitBodyImpl extends ASTWrapperPsiElement implements SmithyTraitBody {
 
-  public SmithyTraitBodyImpl(ASTNode node) {
+  public SmithyTraitBodyImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitBodyValueImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitBodyValueImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyTraitBodyValueImpl extends ASTWrapperPsiElement implements SmithyTraitBodyValue {
 
-  public SmithyTraitBodyValueImpl(ASTNode node) {
+  public SmithyTraitBodyValueImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyTraitImpl extends ASTWrapperPsiElement implements SmithyTrait {
 
-  public SmithyTraitImpl(ASTNode node) {
+  public SmithyTraitImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitStatementsImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitStatementsImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyTraitStatementsImpl extends ASTWrapperPsiElement implements SmithyTraitStatements {
 
-  public SmithyTraitStatementsImpl(ASTNode node) {
+  public SmithyTraitStatementsImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitStructureImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitStructureImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyTraitStructureImpl extends ASTWrapperPsiElement implements SmithyTraitStructure {
 
-  public SmithyTraitStructureImpl(ASTNode node) {
+  public SmithyTraitStructureImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitStructureKvpImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyTraitStructureKvpImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyTraitStructureKvpImpl extends ASTWrapperPsiElement implements SmithyTraitStructureKvp {
 
-  public SmithyTraitStructureKvpImpl(ASTNode node) {
+  public SmithyTraitStructureKvpImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyUseSectionImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyUseSectionImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyUseSectionImpl extends ASTWrapperPsiElement implements SmithyUseSection {
 
-  public SmithyUseSectionImpl(ASTNode node) {
+  public SmithyUseSectionImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyUseStatementImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyUseStatementImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyUseStatementImpl extends ASTWrapperPsiElement implements SmithyUseStatement {
 
-  public SmithyUseStatementImpl(ASTNode node) {
+  public SmithyUseStatementImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyVersionSectionImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyVersionSectionImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyVersionSectionImpl extends ASTWrapperPsiElement implements SmithyVersionSection {
 
-  public SmithyVersionSectionImpl(ASTNode node) {
+  public SmithyVersionSectionImpl(@NotNull ASTNode node) {
     super(node);
   }
 

--- a/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyWsImpl.java
+++ b/src/main/gen/software/amazon/smithy/plugin/language/psi/impl/SmithyWsImpl.java
@@ -28,7 +28,7 @@ import software.amazon.smithy.plugin.language.psi.*;
 
 public class SmithyWsImpl extends ASTWrapperPsiElement implements SmithyWs {
 
-  public SmithyWsImpl(ASTNode node) {
+  public SmithyWsImpl(@NotNull ASTNode node) {
     super(node);
   }
 


### PR DESCRIPTION
This CR upgrades the plugin to use the latest version of gradle-intellij-plugin: `1.4.0`. Upgrade in 70e98ce6d4830efef4f95bf4dcb74224500e694c.

gradle-intellij-plugin now requires Java 11. CI was updated to run on Java 11 and Java 17, dropping Java 8.

The second commit contains the regenerated PSI implementation classes after the upgrade: d560478b2245366d62a3d058183164cf30b9fc60

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
