### PR TITLE
Require Java 11 to support 2020.3 or later

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,6 @@ version = properties("pluginVersion")
 // Configure project's dependencies
 repositories {
     mavenCentral()
-    jcenter()
-    maven(url = "https://jitpack.io")
-    maven(url = "https://www.jetbrains.com/intellij-repository/releases")
 }
 dependencies {
     implementation("com.github.ballerina-platform:lsp4intellij:0.94.2")
@@ -111,21 +108,17 @@ val generateSmithyParser = task<GenerateParser>("generateSmithyParser") {
     purgeOldFiles = true
 }
 
-// The parser generator requires JDK11 or greater. These tasks are run as part of the build only when using an
-// appropriate JDK version.
-if (JavaVersion.current() >= JavaVersion.VERSION_11) {
-    tasks.named("compileJava") { dependsOn("generateSmithyLexer", "generateSmithyParser") }
-} else {
-    val javaVersion = JavaVersion.current();
-    logger.warn("JDK11 or later required to generate Lexer and Parser classes. Changes to Smithy grammar files "
-        + "will not be generated using Java $javaVersion.\nSee README regarding developing the Lexer and Parser.");
-}
-
 tasks {
-    // Set the compatibility versions to 1.8
-    withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+    // Set the JVM compatibility versions
+    properties("javaVersion").let {
+        withType<JavaCompile> {
+            sourceCompatibility = it
+            targetCompatibility = it
+        }
+    }
+
+    wrapper {
+        gradleVersion = properties("gradleVersion")
     }
 
     patchPluginXml {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ platformPlugins =
 javaVersion = 11
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.4
+gradleVersion = 7.4.1
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.


### PR DESCRIPTION
This CR removes deprecated jcenter repository and updates the build to require JDK 11, which was already required for the parser generator, but is now required to support IntelliJ 2020.03 or later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
